### PR TITLE
Add Unichain network support to Tangem app

### DIFF
--- a/app/src/main/assets/tangem-app-config/config_dev.json
+++ b/app/src/main/assets/tangem-app-config/config_dev.json
@@ -129,6 +129,9 @@
 		},
 		"tezos": {
 			"rest": "PLACEHOLDER"
+		},
+		"unichain": {
+			"jsonRpc": "PLACEHOLDER"
 		}
 	},
 	"kaspaSecondaryApiUrl": "PLACEHOLDER",

--- a/app/src/main/assets/tangem-app-config/config_prod.json
+++ b/app/src/main/assets/tangem-app-config/config_prod.json
@@ -129,6 +129,9 @@
 		},
 		"tezos": {
 			"rest": "PLACEHOLDER"
+		},
+		"unichain": {
+			"jsonRpc": "PLACEHOLDER"
 		}
 	},
 	"kaspaSecondaryApiUrl": "PLACEHOLDER",

--- a/core/datasource/src/main/java/com/tangem/datasource/local/config/environment/converter/BlockchainSDKConfigConverter.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/local/config/environment/converter/BlockchainSDKConfigConverter.kt
@@ -105,6 +105,7 @@ internal object BlockchainSDKConfigConverter : Converter<EnvironmentConfigModel,
                 sui = GetBlockAccessToken(jsonRpc = accessTokens.sui?.jsonRPC),
                 telos = GetBlockAccessToken(jsonRpc = accessTokens.telos?.jsonRPC),
                 tezos = GetBlockAccessToken(rest = accessTokens.tezos?.rest),
+                unichain = GetBlockAccessToken(jsonRpc = accessTokens.unichain?.jsonRPC),
             )
         }
     }

--- a/core/datasource/src/main/java/com/tangem/datasource/local/config/environment/models/EnvironmentConfigModel.kt
+++ b/core/datasource/src/main/java/com/tangem/datasource/local/config/environment/models/EnvironmentConfigModel.kt
@@ -85,6 +85,7 @@ data class GetBlockAccessTokens(
     @Json(name = "sui") val sui: GetBlockToken?,
     @Json(name = "telos") val telos: GetBlockToken?,
     @Json(name = "tezos") val tezos: GetBlockToken?,
+    @Json(name = "unichain") val unichain: GetBlockToken?,
 )
 
 @JsonClass(generateAdapter = true)

--- a/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/utils/Blockchain.kt
+++ b/libs/blockchain-sdk/src/main/java/com/tangem/blockchainsdk/utils/Blockchain.kt
@@ -167,6 +167,8 @@ fun Blockchain.Companion.fromNetworkId(networkId: String): Blockchain? {
         "pepecoin/test" -> Blockchain.PepecoinTestnet
         "hyperevm" -> Blockchain.Hyperliquid
         "hyperevm/test" -> Blockchain.HyperliquidTestnet
+        "unichain" -> Blockchain.Unichain
+        "unichain/test" -> Blockchain.UnichainTestnet
         else -> null
     }
 }
@@ -331,6 +333,8 @@ fun Blockchain.toNetworkId(): String {
         Blockchain.PepecoinTestnet -> "pepecoin/test"
         Blockchain.Hyperliquid -> "hyperevm"
         Blockchain.HyperliquidTestnet -> "hyperevm/test"
+        Blockchain.Unichain -> "unichain"
+        Blockchain.UnichainTestnet -> "unichain/test"
     }
 }
 
@@ -435,6 +439,7 @@ fun Blockchain.toCoinId(): String {
         Blockchain.ZkLinkNova, Blockchain.ZkLinkNovaTestnet -> "zklink-ethereum"
         Blockchain.Pepecoin, Blockchain.PepecoinTestnet -> "pepecoin-network"
         Blockchain.Hyperliquid, Blockchain.HyperliquidTestnet -> "hyperliquid"
+        Blockchain.Unichain, Blockchain.UnichainTestnet -> "unichain"
     }
 }
 


### PR DESCRIPTION
- Add network ID mappings for Unichain mainnet and testnet
- Add toCoinId mapping for Unichain
- Add Unichain RPC configuration to config files
- Update BlockchainSDKConfigConverter to handle Unichain tokens
- Update EnvironmentConfigModel with Unichain GetBlock token

This integrates Unichain support into the app layer, allowing users to access Unichain assets with their Tangem wallet.

Requires blockchain-sdk-kotlin with Unichain support.

